### PR TITLE
check isUpsert header in POST document request

### DIFF
--- a/api/handlers/documents.go
+++ b/api/handlers/documents.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 
 	jsonpatch "github.com/evanphx/json-patch/v5"
 	"github.com/gin-gonic/gin"
@@ -221,6 +222,11 @@ func DocumentsPost(c *gin.Context) {
 	if requestBody["id"] == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"message": "BadRequest"})
 		return
+	}
+
+	isUpsert, _ := strconv.ParseBool(c.GetHeader("x-ms-documentdb-is-upsert"))
+	if isUpsert {
+		repositories.DeleteDocument(databaseId, collectionId, requestBody["id"].(string))
 	}
 
 	createdDocument, status := repositories.CreateDocument(databaseId, collectionId, requestBody)

--- a/api/tests/documents_test.go
+++ b/api/tests/documents_test.go
@@ -242,7 +242,6 @@ func Test_Documents_Patch(t *testing.T) {
 		)
 		assert.NotNil(t, r)
 		assert.Nil(t, err2)
-
 	})
 
 	t.Run("CreateItem that already exists", func(t *testing.T) {
@@ -252,7 +251,7 @@ func Test_Documents_Patch(t *testing.T) {
 		bytes, err := json.Marshal(item)
 		assert.Nil(t, err)
 
-		r, err2 := collectionClient.CreateItem(
+		r, err := collectionClient.CreateItem(
 			context,
 			azcosmos.PartitionKey{},
 			bytes,
@@ -261,8 +260,14 @@ func Test_Documents_Patch(t *testing.T) {
 			},
 		)
 		assert.NotNil(t, r)
-		assert.NotNil(t, err2)
+		assert.NotNil(t, err)
 
+		var respErr *azcore.ResponseError
+		if errors.As(err, &respErr) {
+			assert.Equal(t, http.StatusConflict, respErr.StatusCode)
+		} else {
+			panic(err)
+		}
 	})
 
 	t.Run("UpsertItem new", func(t *testing.T) {
@@ -282,7 +287,6 @@ func Test_Documents_Patch(t *testing.T) {
 		)
 		assert.NotNil(t, r)
 		assert.Nil(t, err2)
-
 	})
 
 	t.Run("UpsertItem that already exists", func(t *testing.T) {
@@ -302,7 +306,6 @@ func Test_Documents_Patch(t *testing.T) {
 		)
 		assert.NotNil(t, r)
 		assert.Nil(t, err2)
-
 	})
 
 }

--- a/api/tests/documents_test.go
+++ b/api/tests/documents_test.go
@@ -220,4 +220,89 @@ func Test_Documents_Patch(t *testing.T) {
 			panic(err)
 		}
 	})
+
+	t.Run("CreateItem", func(t *testing.T) {
+		context := context.TODO()
+
+		item := map[string]interface{}{
+			"Id":       "6789011",
+			"pk":       "456",
+			"newField": "newValue2",
+		}
+		bytes, err := json.Marshal(item)
+		assert.Nil(t, err)
+
+		r, err2 := collectionClient.CreateItem(
+			context,
+			azcosmos.PartitionKey{},
+			bytes,
+			&azcosmos.ItemOptions{
+				EnableContentResponseOnWrite: false,
+			},
+		)
+		assert.NotNil(t, r)
+		assert.Nil(t, err2)
+
+	})
+
+	t.Run("CreateItem that already exists", func(t *testing.T) {
+		context := context.TODO()
+
+		item := map[string]interface{}{"id": "12345", "pk": "123", "isCool": false, "arr": []int{1, 2, 3}}
+		bytes, err := json.Marshal(item)
+		assert.Nil(t, err)
+
+		r, err2 := collectionClient.CreateItem(
+			context,
+			azcosmos.PartitionKey{},
+			bytes,
+			&azcosmos.ItemOptions{
+				EnableContentResponseOnWrite: false,
+			},
+		)
+		assert.NotNil(t, r)
+		assert.NotNil(t, err2)
+
+	})
+
+	t.Run("UpsertItem new", func(t *testing.T) {
+		context := context.TODO()
+
+		item := map[string]interface{}{"id": "123456", "pk": "1234", "isCool": false, "arr": []int{1, 2, 3}}
+		bytes, err := json.Marshal(item)
+		assert.Nil(t, err)
+
+		r, err2 := collectionClient.UpsertItem(
+			context,
+			azcosmos.PartitionKey{},
+			bytes,
+			&azcosmos.ItemOptions{
+				EnableContentResponseOnWrite: false,
+			},
+		)
+		assert.NotNil(t, r)
+		assert.Nil(t, err2)
+
+	})
+
+	t.Run("UpsertItem that already exists", func(t *testing.T) {
+		context := context.TODO()
+
+		item := map[string]interface{}{"id": "12345", "pk": "123", "isCool": false, "arr": []int{1, 2, 3, 4}}
+		bytes, err := json.Marshal(item)
+		assert.Nil(t, err)
+
+		r, err2 := collectionClient.UpsertItem(
+			context,
+			azcosmos.PartitionKey{},
+			bytes,
+			&azcosmos.ItemOptions{
+				EnableContentResponseOnWrite: false,
+			},
+		)
+		assert.NotNil(t, r)
+		assert.Nil(t, err2)
+
+	})
+
 }


### PR DESCRIPTION
#### Summary
Added check for upsert header. Delete existing item before (re-)inserting item if upsert header is present.
Before, upsert requests to existing items resulted in http statuscode 409 conflict errors.

Test named "UpsertItem that already exists" was added to confirm fix. Other tests are to check that the change didn't break anything related.

Upsert in REST api doc:
https://learn.microsoft.com/en-us/rest/api/cosmos-db/create-a-document

Upsert in client golang client implementation:
https://github.com/Azure/azure-sdk-for-go/blob/sdk/data/azcosmos/v1.1.0/sdk/data/azcosmos/cosmos_container.go
