### PR TITLE
Fix shared library tests for windows

### DIFF
--- a/.github/workflows/compile-shared-libraries.yml
+++ b/.github/workflows/compile-shared-libraries.yml
@@ -24,6 +24,19 @@ jobs:
           buildmode: c-shared
           buildvcs: true
 
+      - name: Install MinGW for cross-compilation
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-mingw-w64-x86-64 gcc-aarch64-linux-gnu
+
+      - name: Build tests for Linux
+        run: |
+          gcc -Wall -ldl -o dist/sharedlibrary_test_linux sharedlibrary/tests/*.c
+
+      - name: Build tests for Windows
+        run: |
+          x86_64-w64-mingw32-gcc -Wall -o dist/sharedlibrary_test_windows.exe sharedlibrary/tests/*.c
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,17 @@ GOVERSION=1.24.7
 DIST_DIR=dist
 
 SHARED_LIB_TEST_CC=gcc
-SHARED_LIB_TEST_CFLAGS=-Wall -ldl
-SHARED_LIB_TEST_TARGET=$(DIST_DIR)/sharedlibrary_test
 SHARED_LIB_TEST_DIR=./sharedlibrary/tests
 SHARED_LIB_TEST_SOURCES=$(wildcard $(SHARED_LIB_TEST_DIR)/*.c)
+
+# Platform-specific settings
+ifeq ($(OS),Windows_NT)
+    SHARED_LIB_TEST_TARGET=$(DIST_DIR)/sharedlibrary_test.exe
+    SHARED_LIB_TEST_CFLAGS=-Wall
+else
+    SHARED_LIB_TEST_TARGET=$(DIST_DIR)/sharedlibrary_test
+    SHARED_LIB_TEST_CFLAGS=-Wall -ldl
+endif
 
 all: test build-all
 
@@ -57,7 +64,13 @@ build-sharedlib-darwin-arm64:
 
 build-sharedlib-tests: build-sharedlib-linux-amd64
 	@echo "Building shared library tests..."
+	@mkdir -p $(DIST_DIR)
 	@$(SHARED_LIB_TEST_CC) $(SHARED_LIB_TEST_CFLAGS) -o $(SHARED_LIB_TEST_TARGET) $(SHARED_LIB_TEST_SOURCES)
+
+build-sharedlib-tests-windows:
+	@echo "Building shared library tests for Windows..."
+	@mkdir -p $(DIST_DIR)
+	@x86_64-w64-mingw32-gcc -Wall -o $(DIST_DIR)/sharedlibrary_test.exe $(SHARED_LIB_TEST_SOURCES)
 
 run-sharedlib-tests: build-sharedlib-tests
 	@echo "Running shared library tests..."
@@ -80,4 +93,4 @@ clean:
 	@$(GOCLEAN)
 	@rm -rf $(DIST_DIR)
 
-.PHONY: all test build-all build-macos build-linux clean generate-parser-nosql
+.PHONY: all test build-all build-macos build-linux clean generate-parser-nosql build-sharedlib-tests build-sharedlib-tests-windows run-sharedlib-tests xgo-compile-sharedlib

--- a/sharedlibrary/tests/main.c
+++ b/sharedlibrary/tests/main.c
@@ -14,10 +14,10 @@ int main(int argc, char *argv[])
     }
 
     const char *libPath = argv[1];
-    handle = dlopen(libPath, RTLD_LAZY);
+    handle = load_library(libPath);
     if (!handle)
     {
-        fprintf(stderr, "Failed to load shared library: %s\n", dlerror());
+        fprintf(stderr, "Failed to load shared library: %s\n", get_load_error());
         return EXIT_FAILURE;
     }
 
@@ -41,6 +41,6 @@ int main(int argc, char *argv[])
 
     printf("Tests passed: %d/%d\n", numPassed, numTests);
 
-    dlclose(handle);
+    close_library(handle);
     return EXIT_SUCCESS;
 }

--- a/sharedlibrary/tests/shared.c
+++ b/sharedlibrary/tests/shared.c
@@ -1,13 +1,54 @@
 #include "shared.h"
 
-void *handle = NULL;
+lib_handle_t handle = NULL;
 
+// Platform-specific error handling
+char *get_load_error(void)
+{
+#ifdef _WIN32
+    DWORD error = GetLastError();
+    static char buf[256];
+    FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                   NULL, error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                   buf, sizeof(buf), NULL);
+    return buf;
+#else
+    return dlerror();
+#endif
+}
+
+// Platform-specific library loading
+lib_handle_t load_library(const char *path)
+{
+#ifdef _WIN32
+    return LoadLibraryA(path);
+#else
+    return dlopen(path, RTLD_LAZY);
+#endif
+}
+
+// Platform-specific library closing
+void close_library(lib_handle_t handle)
+{
+#ifdef _WIN32
+    FreeLibrary(handle);
+#else
+    dlclose(handle);
+#endif
+}
+
+// Platform-specific function loading
 void *load_function(const char *func_name)
 {
+#ifdef _WIN32
+    void *func = (void *)GetProcAddress(handle, func_name);
+#else
     void *func = dlsym(handle, func_name);
+#endif
+    
     if (!func)
     {
-        fprintf(stderr, "Failed to load function %s: %s\n", func_name, dlerror());
+        fprintf(stderr, "Failed to load function %s: %s\n", func_name, get_load_error());
     }
     return func;
 }

--- a/sharedlibrary/tests/shared.h
+++ b/sharedlibrary/tests/shared.h
@@ -3,13 +3,24 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <dlfcn.h>
 #include <string.h>
 #include <ctype.h>
 
-extern void *handle;
+// Platform-specific includes for dynamic library loading
+#ifdef _WIN32
+    #include <windows.h>
+    typedef HMODULE lib_handle_t;
+#else
+    #include <dlfcn.h>
+    typedef void* lib_handle_t;
+#endif
+
+extern lib_handle_t handle;
 
 void *load_function(const char *func_name);
 char *compact_json(const char *json);
+char *get_load_error(void);
+lib_handle_t load_library(const char *path);
+void close_library(lib_handle_t handle);
 
 #endif


### PR DESCRIPTION
#### Summary
This PR addresses the failure to build `sharedlibrary/tests` on Windows by making the dynamic library loading and error handling cross-platform.

The changes introduce platform-agnostic wrappers for functions like `dlopen`, `dlsym`, `dlclose`, and `dlerror` using conditional compilation (`#ifdef _WIN32`). This allows the tests to use Windows API functions (`LoadLibraryA`, `GetProcAddress`, `FreeLibrary`, `GetLastError`) on Windows and the existing `dlfcn.h` functions on Unix-like systems.

The `Makefile` has been updated to support Windows builds, including a new target for cross-compiling tests with MinGW. The CI workflow (`compile-shared-libraries.yml`) now includes steps to install MinGW and build the tests for both Linux and Windows to validate cross-platform compatibility.

#### Ticket Link
N/A

---
<a href="https://cursor.com/background-agent?bcId=bc-7ef26520-9bb7-4f82-bcf1-db2a8dd6b9fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7ef26520-9bb7-4f82-bcf1-db2a8dd6b9fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

