### PR TITLE
Fix ARRAY_CONTAINS panic when optional partial-match argument is omitted

### DIFF
--- a/api/tests/documents_array_functions_test.go
+++ b/api/tests/documents_array_functions_test.go
@@ -12,9 +12,6 @@ func Test_Documents_ArrayContains(t *testing.T) {
 	runTestsWithPresets(t, "Test_Documents_ArrayContains", presets, func(t *testing.T, ts *TestServer, client *azcosmos.Client) {
 		collectionClient := documents_InitializeDb(t, ts)
 
-		// Regression test: ARRAY_CONTAINS without the optional partial match
-		// argument used to panic because the parser always emits a third
-		// (nil) argument, which the executor blindly type-asserted.
 		t.Run("Should execute ARRAY_CONTAINS() without partial match argument", func(t *testing.T) {
 			testCosmosQuery(t, collectionClient,
 				`SELECT VALUE ARRAY_CONTAINS(["apple", "banana", "cherry"], "banana") FROM c ORDER BY c.id`,
@@ -31,7 +28,6 @@ func Test_Documents_ArrayContains(t *testing.T) {
 			)
 		})
 
-		// Full object match (no partial match argument).
 		t.Run("Should execute ARRAY_CONTAINS() with object full match", func(t *testing.T) {
 			testCosmosQuery(t, collectionClient,
 				`SELECT VALUE ARRAY_CONTAINS([{"name": "apple", "color": "red"}], {"name": "apple"}) FROM c ORDER BY c.id`,
@@ -40,7 +36,6 @@ func Test_Documents_ArrayContains(t *testing.T) {
 			)
 		})
 
-		// Partial object match (partial match argument set to true).
 		t.Run("Should execute ARRAY_CONTAINS() with object partial match", func(t *testing.T) {
 			testCosmosQuery(t, collectionClient,
 				`SELECT VALUE ARRAY_CONTAINS([{"name": "apple", "color": "red"}], {"name": "apple"}, true) FROM c ORDER BY c.id`,

--- a/api/tests/documents_array_functions_test.go
+++ b/api/tests/documents_array_functions_test.go
@@ -1,0 +1,52 @@
+package tests_test
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+)
+
+func Test_Documents_ArrayContains(t *testing.T) {
+	presets := []testPreset{PresetJsonStore, PresetBadgerStore}
+
+	runTestsWithPresets(t, "Test_Documents_ArrayContains", presets, func(t *testing.T, ts *TestServer, client *azcosmos.Client) {
+		collectionClient := documents_InitializeDb(t, ts)
+
+		// Regression test: ARRAY_CONTAINS without the optional partial match
+		// argument used to panic because the parser always emits a third
+		// (nil) argument, which the executor blindly type-asserted.
+		t.Run("Should execute ARRAY_CONTAINS() without partial match argument", func(t *testing.T) {
+			testCosmosQuery(t, collectionClient,
+				`SELECT VALUE ARRAY_CONTAINS(["apple", "banana", "cherry"], "banana") FROM c ORDER BY c.id`,
+				nil,
+				[]interface{}{true, true},
+			)
+		})
+
+		t.Run("Should execute ARRAY_CONTAINS() returning false for missing item", func(t *testing.T) {
+			testCosmosQuery(t, collectionClient,
+				`SELECT VALUE ARRAY_CONTAINS(["apple", "banana", "cherry"], "grape") FROM c ORDER BY c.id`,
+				nil,
+				[]interface{}{false, false},
+			)
+		})
+
+		// Full object match (no partial match argument).
+		t.Run("Should execute ARRAY_CONTAINS() with object full match", func(t *testing.T) {
+			testCosmosQuery(t, collectionClient,
+				`SELECT VALUE ARRAY_CONTAINS([{"name": "apple", "color": "red"}], {"name": "apple"}) FROM c ORDER BY c.id`,
+				nil,
+				[]interface{}{false, false},
+			)
+		})
+
+		// Partial object match (partial match argument set to true).
+		t.Run("Should execute ARRAY_CONTAINS() with object partial match", func(t *testing.T) {
+			testCosmosQuery(t, collectionClient,
+				`SELECT VALUE ARRAY_CONTAINS([{"name": "apple", "color": "red"}], {"name": "apple"}, true) FROM c ORDER BY c.id`,
+				nil,
+				[]interface{}{true, true},
+			)
+		})
+	})
+}

--- a/query_executors/memory_executor/array_functions.go
+++ b/query_executors/memory_executor/array_functions.go
@@ -25,7 +25,7 @@ func (r rowContext) array_Contains(arguments []interface{}) bool {
 	exprToSearch := r.resolveSelectItem(arguments[1].(parsers.SelectItem))
 
 	partialSearch := false
-	if len(arguments) > 2 {
+	if len(arguments) > 2 && arguments[2] != nil {
 		boolExpr := r.resolveSelectItem(arguments[2].(parsers.SelectItem))
 		if boolValue, ok := boolExpr.(bool); ok {
 			partialSearch = boolValue


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`ARRAY_CONTAINS` crashes the query handler (HTTP 500, server-side panic) whenever it is called without the optional partial-match argument, e.g.:

```sql
SELECT ARRAY_CONTAINS(c.arr, 2) FROM c
```

### Root cause

Parsing is fine, the bug is in execution. The NoSQL grammar always produces **three** arguments for `ARRAY_CONTAINS` — `array`, `item`, and `partialMatch` — where `partialMatch` is `nil` when the caller omits it:

```
ArrayContainsExpression <- "ARRAY_CONTAINS"i ... partialMatch:(...)? ... {
    return createFunctionCall(parsers.FunctionCallArrayContains, []interface{}{array, item, partialMatch})
}
```

The executor, however, only checked `len(arguments) > 2` before unconditionally type-asserting the third argument:

```go
if len(arguments) > 2 {
    boolExpr := r.resolveSelectItem(arguments[2].(parsers.SelectItem)) // panics on nil
}
```

Since the slice always has length 3, the condition is always true, and the `nil` partial-match value triggers `interface conversion: interface {} is nil, not parsers.SelectItem`.

### Fix

Guard the type assertion with a `nil` check, matching how the other functions with optional arguments (`getBoolFlag`, `strings_IndexOf`, `array_Slice`) already handle it:

```go
if len(arguments) > 2 && arguments[2] != nil {
    ...
}
```

I also audited every other function that the grammar can emit with a `nil` placeholder for an omitted optional argument (`STRINGEQUALS`, `CONTAINS`/`ENDSWITH`/`STARTSWITH`, `INDEX_OF`, `ARRAY_SLICE`); they all already guard against `nil`, so `ARRAY_CONTAINS` was the only offender.

## Tests

Added an API-level test (`api/tests/documents_array_functions_test.go`) that exercises `ARRAY_CONTAINS` end-to-end through the HTTP/Cosmos SDK path, against both the JSON and Badger datastore presets:

- `ARRAY_CONTAINS` **without** the partial-match argument (the regression — previously panicked)
- `ARRAY_CONTAINS` returning `false` for a missing item
- `ARRAY_CONTAINS` with full object match
- `ARRAY_CONTAINS` with object partial match (`true`)

The test uses literal arrays to stay independent of numeric type-coercion differences between the datastores. Verified the test reproduces the panic before the fix and passes after. Existing `query_executors/...` and `parsers/...` suites continue to pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34e2d5f1-da93-47ae-8610-ac82aa7384b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34e2d5f1-da93-47ae-8610-ac82aa7384b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

