### PR TITLE
Add document ETag optimistic concurrency

### DIFF
--- a/api/handlers/documents.go
+++ b/api/handlers/documents.go
@@ -47,6 +47,9 @@ func (h *Handlers) GetDocument(c *gin.Context) {
 
 	document, status := h.dataStore.GetDocument(databaseId, collectionId, documentId)
 	if status == datastore.StatusOk {
+		if etag, ok := document["_etag"].(string); ok {
+			c.Header(headers.ETag, etag)
+		}
 		c.IndentedJSON(http.StatusOK, document)
 		return
 	}
@@ -90,7 +93,24 @@ func (h *Handlers) ReplaceDocument(c *gin.Context) {
 		return
 	}
 
-	status := h.dataStore.DeleteDocument(databaseId, collectionId, documentId)
+	existingDocument, status := h.dataStore.GetDocument(databaseId, collectionId, documentId)
+	if status == datastore.StatusNotFound {
+		c.IndentedJSON(http.StatusNotFound, constants.NotFoundResponse)
+		return
+	}
+	if status != datastore.StatusOk {
+		c.IndentedJSON(http.StatusInternalServerError, constants.UnknownErrorResponse)
+		return
+	}
+
+	if ifMatch := c.GetHeader(headers.IfMatch); ifMatch != "" {
+		if existingDocument["_etag"] != ifMatch {
+			c.JSON(http.StatusPreconditionFailed, constants.PreconditionFailedResponse)
+			return
+		}
+	}
+
+	status = h.dataStore.DeleteDocument(databaseId, collectionId, documentId)
 	if status == datastore.StatusNotFound {
 		c.IndentedJSON(http.StatusNotFound, constants.NotFoundResponse)
 		return

--- a/api/handlers/documents.go
+++ b/api/handlers/documents.go
@@ -105,6 +105,7 @@ func (h *Handlers) ReplaceDocument(c *gin.Context) {
 
 	if ifMatch := c.GetHeader(headers.IfMatch); ifMatch != "" {
 		if existingDocument["_etag"] != ifMatch {
+			c.Header(headers.ErrorCode, "PreconditionFailed")
 			c.JSON(http.StatusPreconditionFailed, constants.PreconditionFailedResponse)
 			return
 		}

--- a/api/headers/headers.go
+++ b/api/headers/headers.go
@@ -4,6 +4,7 @@ const (
 	AIM                = "A-Im"
 	Authorization      = "authorization"
 	CosmosLsn          = "x-ms-cosmos-llsn"
+	ErrorCode          = "x-ms-error-code"
 	ETag               = "etag"
 	GlobalCommittedLsn = "x-ms-global-committed-lsn"
 	IfMatch            = "if-match"

--- a/api/headers/headers.go
+++ b/api/headers/headers.go
@@ -6,6 +6,7 @@ const (
 	CosmosLsn          = "x-ms-cosmos-llsn"
 	ETag               = "etag"
 	GlobalCommittedLsn = "x-ms-global-committed-lsn"
+	IfMatch            = "if-match"
 	IfNoneMatch        = "if-none-match"
 	IsBatchRequest     = "x-ms-cosmos-is-batch-request"
 	IsQueryPlanRequest = "x-ms-cosmos-is-query-plan-request"

--- a/api/tests/documents_test.go
+++ b/api/tests/documents_test.go
@@ -403,7 +403,7 @@ func Test_Documents(t *testing.T) {
 			var respErr *azcore.ResponseError
 			if errors.As(err, &respErr) {
 				assert.Equal(t, http.StatusPreconditionFailed, respErr.StatusCode)
-				assert.Equal(t, "PreconditionFailed", respErr.ErrorCode)
+				assert.Equal(t, "PreconditionFailed", respErr.RawResponse.Header.Get("x-ms-error-code"))
 
 				responseBody, readErr := io.ReadAll(respErr.RawResponse.Body)
 				assert.Nil(t, readErr)

--- a/api/tests/documents_test.go
+++ b/api/tests/documents_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"reflect"
 	"sync"
@@ -376,6 +377,80 @@ func Test_Documents(t *testing.T) {
 			)
 			assert.NotNil(t, r)
 			assert.Nil(t, err2)
+		})
+	})
+
+	runTestsWithPresets(t, "Test_Documents_ETag_OptimisticConcurrency", presets, func(t *testing.T, ts *TestServer, client *azcosmos.Client) {
+		collectionClient := documents_InitializeDb(t, ts)
+
+		t.Run("Should fail replace with incorrect etag", func(t *testing.T) {
+			context := context.TODO()
+
+			item := map[string]interface{}{"id": "12345", "pk": "123", "isCool": true}
+			bytes, err := json.Marshal(item)
+			assert.Nil(t, err)
+
+			wrongETag := azcore.ETag("\"incorrect-etag\"")
+			_, err = collectionClient.ReplaceItem(
+				context,
+				azcosmos.PartitionKey{},
+				"12345",
+				bytes,
+				&azcosmos.ItemOptions{IfMatchEtag: &wrongETag},
+			)
+			assert.NotNil(t, err)
+
+			var respErr *azcore.ResponseError
+			if errors.As(err, &respErr) {
+				assert.Equal(t, http.StatusPreconditionFailed, respErr.StatusCode)
+				assert.Equal(t, "PreconditionFailed", respErr.ErrorCode)
+
+				responseBody, readErr := io.ReadAll(respErr.RawResponse.Body)
+				assert.Nil(t, readErr)
+				assert.JSONEq(t,
+					`{"code":"PreconditionFailed","message":"Operation cannot be performed because one of the specified precondition is not met."}`,
+					string(responseBody),
+				)
+			} else {
+				panic(err)
+			}
+
+			document, status := ts.DataStore.GetDocument(testDatabaseName, testCollectionName, "12345")
+			assert.Equal(t, datastore.StatusOk, status)
+			assert.Equal(t, false, document["isCool"])
+		})
+
+		t.Run("Should replace with correct etag", func(t *testing.T) {
+			context := context.TODO()
+
+			readResponse, err := collectionClient.ReadItem(context, azcosmos.PartitionKey{}, "12345", nil)
+			assert.Nil(t, err)
+			assert.NotEmpty(t, readResponse.ETag)
+
+			var item map[string]interface{}
+			err = json.Unmarshal(readResponse.Value, &item)
+			assert.Nil(t, err)
+			assert.Equal(t, string(readResponse.ETag), item["_etag"])
+
+			item["pk"] = "999"
+			item["isCool"] = true
+			bytes, err := json.Marshal(item)
+			assert.Nil(t, err)
+
+			etag := readResponse.ETag
+			_, err = collectionClient.ReplaceItem(
+				context,
+				azcosmos.PartitionKey{},
+				"12345",
+				bytes,
+				&azcosmos.ItemOptions{IfMatchEtag: &etag},
+			)
+			assert.Nil(t, err)
+
+			document, status := ts.DataStore.GetDocument(testDatabaseName, testCollectionName, "12345")
+			assert.Equal(t, datastore.StatusOk, status)
+			assert.Equal(t, "999", document["pk"])
+			assert.Equal(t, true, document["isCool"])
 		})
 	})
 

--- a/internal/constants/responses.go
+++ b/internal/constants/responses.go
@@ -35,3 +35,7 @@ var UnknownErrorResponse = gin.H{"message": "Unknown error"}
 var NotFoundResponse = gin.H{"message": "NotFound"}
 var ConflictResponse = gin.H{"message": "Conflict"}
 var BadRequestResponse = gin.H{"message": "BadRequest"}
+var PreconditionFailedResponse = gin.H{
+	"code":    "PreconditionFailed",
+	"message": "Operation cannot be performed because one of the specified precondition is not met.",
+}

--- a/internal/datastore/badger_datastore/badger_datastore.go
+++ b/internal/datastore/badger_datastore/badger_datastore.go
@@ -12,8 +12,10 @@ import (
 )
 
 type BadgerDataStore struct {
-	db       *badger.DB
-	gcTicker *time.Ticker
+	db        *badger.DB
+	gcTicker  *time.Ticker
+	gcDone    chan struct{}
+	gcStopped chan struct{}
 }
 
 type BadgerDataStoreOptions struct {
@@ -36,8 +38,10 @@ func NewBadgerDataStore(options BadgerDataStoreOptions) *BadgerDataStore {
 	gcTicker := time.NewTicker(5 * time.Minute)
 
 	ds := &BadgerDataStore{
-		db:       db,
-		gcTicker: gcTicker,
+		db:        db,
+		gcTicker:  gcTicker,
+		gcDone:    make(chan struct{}),
+		gcStopped: make(chan struct{}),
 	}
 
 	ds.initializeDataStore(options.InitialDataFilePath)
@@ -50,7 +54,8 @@ func NewBadgerDataStore(options BadgerDataStoreOptions) *BadgerDataStore {
 func (r *BadgerDataStore) Close() {
 	if r.gcTicker != nil {
 		r.gcTicker.Stop()
-		r.gcTicker = nil
+		close(r.gcDone)
+		<-r.gcStopped
 	}
 
 	r.db.Close()
@@ -63,11 +68,19 @@ func (r *BadgerDataStore) DumpToJson() (string, error) {
 }
 
 func (r *BadgerDataStore) runGarbageCollector() {
-	for range r.gcTicker.C {
-	again:
-		err := r.db.RunValueLogGC(0.7)
-		if err == nil {
-			goto again
+	defer close(r.gcStopped)
+
+	for {
+		select {
+		case <-r.gcTicker.C:
+			for {
+				err := r.db.RunValueLogGC(0.7)
+				if err != nil {
+					break
+				}
+			}
+		case <-r.gcDone:
+			return
 		}
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
- Return document `_etag` values in the `etag` response header for single document reads.
- Honor optional `If-Match` headers on document replace requests and return 412 PreconditionFailed for stale ETags.
- Add Cosmos SDK replace tests for incorrect and correct ETag preconditions.
- Stop the Badger datastore GC goroutine before closing the datastore to keep Badger-backed API tests stable.

QA:
- `go test ./api/tests -run '^Test_Documents$/.*ETag' -v`
- `go test ./api/tests`
- `go test ./...`

#### Ticket Link
N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9028c0a3-db14-4642-b3c7-f6259b6ea2f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9028c0a3-db14-4642-b3c7-f6259b6ea2f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

